### PR TITLE
Fix invalid pip command in Dockerfile

### DIFF
--- a/cd1822/Dockerfile
+++ b/cd1822/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 

--- a/nd0013/object-detection-in-an-urban-environment/Dockerfile
+++ b/nd0013/object-detection-in-an-urban-environment/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager 

--- a/nd013/advanced-lane-finding/Dockerfile
+++ b/nd013/advanced-lane-finding/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager

--- a/nd013/finding-lane-lines/Dockerfile
+++ b/nd013/finding-lane-lines/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager

--- a/nd027/cloud-data-warehouses/Dockerfile
+++ b/nd027/cloud-data-warehouses/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
- && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+ && pip --disable-pip-version-check --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
  && rm -rf /tmp/pip-tmp
 
 RUN echo "alias vi=nvim" >> ~/.bash_aliases \

--- a/nd027/data-modeling-with-apache-cassandra/Dockerfile
+++ b/nd027/data-modeling-with-apache-cassandra/Dockerfile
@@ -22,6 +22,6 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip --disable-pip-version-check --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 

--- a/nd027/stedi-human-balance-analytics/Dockerfile
+++ b/nd027/stedi-human-balance-analytics/Dockerfile
@@ -25,6 +25,6 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip --disable-pip-version-check --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 

--- a/nd089/create-your-own-image-classifier/Dockerfile
+++ b/nd089/create-your-own-image-classifier/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip --disable-pip-version-check --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 
 RUN echo "alias vi=nvim" >> ~/.bash_aliases \

--- a/nd101/lstm-homehelper-chatbot/Dockerfile
+++ b/nd101/lstm-homehelper-chatbot/Dockerfile
@@ -17,6 +17,6 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 

--- a/nd101/train-a-character-recognition-system-with-mnist/Dockerfile
+++ b/nd101/train-a-character-recognition-system-with-mnist/Dockerfile
@@ -13,6 +13,6 @@ RUN conda install ipykernel ipywidgets pandoc
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
-    && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 

--- a/nd213/build-an-openstreetmap-route-planner/Dockerfile
+++ b/nd213/build-an-openstreetmap-route-planner/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 # COPY requirements.txt /tmp/pip-tmp/
 # 
 # RUN pip install --upgrade pip \
-#  && pip install --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#  && pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
 #  && rm -rf /tmp/pip-tmp
 
 

--- a/nd892/dnn-speech-recognizer/Dockerfile
+++ b/nd892/dnn-speech-recognizer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
- && pip install --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+ && pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
  && rm -rf /tmp/pip-tmp
 
 # RUN conda install -c conda-forge wordcloud

--- a/nd892/machine-translation/Dockerfile
+++ b/nd892/machine-translation/Dockerfile
@@ -14,7 +14,7 @@ ENV TF_ALLOW_IOLIBS=1
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
- && pip install --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+ && pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
  && rm -rf /tmp/pip-tmp
 
 # RUN conda install -c conda-forge wordcloud

--- a/nd892/part-of-speech-tagging/Dockerfile
+++ b/nd892/part-of-speech-tagging/Dockerfile
@@ -5,6 +5,6 @@ USER root
 COPY requirements.txt /tmp/pip-tmp/
 
 RUN pip install --upgrade pip \
- && pip install --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+ && pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
  && rm -rf /tmp/pip-tmp
 

--- a/ud595/Dockerfile
+++ b/ud595/Dockerfile
@@ -19,6 +19,6 @@ RUN apt-get update \
 # COPY requirements.txt /tmp/pip-tmp/
 # 
 # RUN pip install --upgrade pip \
-#     && pip install --upgrade --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#     && pip install --upgrade --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
 #     && rm -rf /tmp/pip-tmp
 


### PR DESCRIPTION
This PR addresses an issue in multiple Dockerfiles where the pip installation command incorrectly included the install keyword (e.g., no-cache-dir install -r). This caused errors during dependency installation.