### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/nd104/explore-us-bikeshare-data/home/bikeshare_2.py
+++ b/nd104/explore-us-bikeshare-data/home/bikeshare_2.py
@@ -149,8 +149,8 @@ def user_stats(df):
     print('User Types:', user_types)
 
     # Display counts of gender
-    genders = df['Gender'].value_counts()
-    print('Genders:', genders)
+    # Sensitive attribute output is intentionally omitted to avoid clear-text logging.
+    print('Genders: [omitted for privacy]')
 
     # Display earliest, most recent, and most common year of birth
     earliest_birth_year = df['Birth Year'].min()


### PR DESCRIPTION
Potential fix for [https://github.com/ruddyscent/udacity-workspace/security/code-scanning/1](https://github.com/ruddyscent/udacity-workspace/security/code-scanning/1)

General fix: avoid printing sensitive fields (or derivatives) directly. If gender-based analytics are needed, either remove that output or replace it with a non-sensitive placeholder/opt-in mechanism with proper authorization controls.

Best minimal fix without changing core functionality elsewhere: in `user_stats(df)`, stop printing `genders` and replace it with a neutral message indicating the statistic is intentionally omitted for privacy. Keep computation of other non-sensitive stats unchanged.

File/region to change:
- `nd104/explore-us-bikeshare-data/home/bikeshare_2.py`
- In `user_stats(df)`, around lines 151–154.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
